### PR TITLE
Inserted the typing module

### DIFF
--- a/apps/high_cpu/requirements.txt
+++ b/apps/high_cpu/requirements.txt
@@ -1,3 +1,4 @@
+typing==3.10.0.0
 backports-abc==0.4
 certifi==2016.9.26
 click==6.6


### PR DESCRIPTION
Needed it because of the following error:

[ec2-user@ip-172-31-32-99 high_cpu]$ sudo pip install -r requirements.txt
Traceback (most recent call last):
File "/bin/pip", line 11, in <module>
load_entry_point('pip==21.1.2', 'console_scripts', 'pip')()
File "/usr/lib/python2.7/site-packages/pkg_resources/__init__.py", line 489, in load_entry_point
return get_distribution(dist).load_entry_point(group, name)
File "/usr/lib/python2.7/site-packages/pkg_resources/__init__.py", line 2852, in load_entry_point
return ep.load()
File "/usr/lib/python2.7/site-packages/pkg_resources/__init__.py", line 2443, in load
return self.resolve()
File "/usr/lib/python2.7/site-packages/pkg_resources/__init__.py", line 2449, in resolve
module = __import__(self.module_name, fromlist=['__name__'], level=0)
File "/usr/lib/python2.7/site-packages/pip-21.1.2-py2.7.egg/pip/__init__.py", line 1, in <module>
from typing import List, Optional
ImportError: No module named typing